### PR TITLE
bugfix: missing screenshot filename

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -40,6 +40,10 @@ class HtmlReporter extends events.EventEmitter {
     })
 
     this.on('runner:screenshot', function (runner) {
+      // if the filename isn't defined, it cannot find the file and cannot be added to the report
+      if (!runner.filename) {
+        return
+      }
       const cid = runner.cid
       const stats = this.baseReporter.stats
       const results = stats.runners[cid]
@@ -51,6 +55,10 @@ class HtmlReporter extends events.EventEmitter {
     })
 
     this.on('screenshot:fullpage', function (data) {
+      // if the filename isn't defined, it cannot find the file and cannot be added to the report
+      if (!data.filename) {
+        return
+      }
       const cid = data.cid
       const stats = this.baseReporter.stats
       const results = stats.runners[cid]


### PR DESCRIPTION
Handling error when users don't enter a filename when taking basic screenshots